### PR TITLE
Refactor Fetch.Result

### DIFF
--- a/lib/fetch/result.ex
+++ b/lib/fetch/result.ex
@@ -7,13 +7,15 @@ defmodule Fetch.Result do
 
   @opaque t() :: %__MODULE__{}
 
-  @enforce_keys [:assets, :links]
-  defstruct [:assets, :links]
+  defstruct assets: [],
+            links: []
 
-  def new(assets \\ [], links \\ []) do
+  def new(assets, links) when is_list(assets) and is_list(links) do
     %__MODULE__{
       assets: assets,
       links: links
     }
   end
+
+  def new(_assets, _links), do: %__MODULE__{}
 end

--- a/test/fetch/regex_parser_test.exs
+++ b/test/fetch/regex_parser_test.exs
@@ -9,6 +9,10 @@ defmodule Fetch.RegexParserTest do
   @link_one "<a href=\"http://link1\">link one</a>"
   @link_two "<a href=\"http://link2\">link two</a>"
 
+  test "can i break the thing" do
+    assert Fetch.Result.new(nil, nil) == %Fetch.Result{assets: [], links: []}
+  end
+
   test "parses empty string" do
     result = Parser.parse("")
 

--- a/test/fetch/result_test.exs
+++ b/test/fetch/result_test.exs
@@ -1,0 +1,13 @@
+defmodule Fetch.ResultTest do
+  use ExUnit.Case
+  alias Fetch.Result
+  doctest Result
+
+  test "new/1 with valid arguments" do
+    assert Result.new([1], [2]) == %Result{assets: [1], links: [2]}
+  end
+
+  test "new/1 with invalid arguments" do
+    assert Result.new(nil, nil) == %Result{assets: [], links: []}
+  end
+end


### PR DESCRIPTION
This commit adds a test for the `Result` struct, and refactors the code
to prevent `nils` leaking into the values within our structure. This
will remove the need to handle `nil` edge cases in the future.